### PR TITLE
Allow `stylelint` version `15.0.0` and `16.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector/issues"
   },
   "peerDependencies": {
-    "stylelint": "^13.0.0 || ^14.0.0"
+    "stylelint": "^13.0.0 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector/issues"
   },
   "peerDependencies": {
-    "stylelint": "^13.0.0 || ^14.0.0 || ^15.0.0"
+    "stylelint": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.21",


### PR DESCRIPTION
Adds `^15.0.0 | ^16.0.0` to the allowed peer dependencies. We have installed this in GitHub Primer's stylelint configuration (https://github.com/primer/stylelint-config/pull/414) via overrides and everything has worked fine in our internal codebases, so I think this is safe to ship:

```json
{
  "devDependencies": {
    "stylelint": "^16.3.1",
    "stylelint-css-modules-no-global-scoped-selector": "^1.0.2"
  },
  "overrides": {
    "stylelint-css-modules-no-global-scoped-selector": {
      "stylelint": "$stylelint"
    }
  }
}
```

- Closes https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector/issues/3
- Closes https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector/issues/4

cc @lmichelin 